### PR TITLE
Better-behaved Show instance for Encoding

### DIFF
--- a/src/Node/Buffer.purs
+++ b/src/Node/Buffer.purs
@@ -87,7 +87,7 @@ foreign import fromArray :: forall e. Array Octet -> Eff (buffer :: BUFFER | e) 
 -- | Creates a new buffer from a string with the specified encoding, sized to
 -- | match the string.
 fromString :: forall e. String -> Encoding -> Eff (buffer :: BUFFER | e) Buffer
-fromString str = fromStringImpl str <<< show
+fromString str = fromStringImpl str <<< encodingToNode
 
 foreign import fromStringImpl :: forall e. String -> String -> Eff (buffer :: BUFFER | e) Buffer
 
@@ -99,14 +99,14 @@ foreign import readImpl :: forall e. String -> Offset -> Buffer -> Eff (buffer :
 
 -- | Reads a section of a buffer as a string with the specified encoding.
 readString :: forall e. Encoding -> Offset -> Offset -> Buffer -> Eff (buffer :: BUFFER | e) String
-readString = readStringImpl <<< show
+readString = readStringImpl <<< encodingToNode
 
 foreign import readStringImpl ::
   forall e. String -> Offset -> Offset -> Buffer -> Eff (buffer :: BUFFER | e) String
 
 -- | Reads the buffer as a string with the specified encoding.
 toString :: forall e. Encoding -> Buffer -> Eff (buffer :: BUFFER | e) String
-toString = toStringImpl <<< show
+toString = toStringImpl <<< encodingToNode
 
 foreign import toStringImpl :: forall e. String -> Buffer -> Eff (buffer :: BUFFER | e) String
 
@@ -121,7 +121,7 @@ foreign import writeImpl ::
 -- | characters will not be written to the buffer if there is not enough capacity
 -- | to write them fully. The number of bytes written is returned.
 writeString :: forall e. Encoding -> Offset -> Int -> String -> Buffer -> Eff (buffer :: BUFFER | e) Int
-writeString = writeStringImpl <<< show
+writeString = writeStringImpl <<< encodingToNode
 
 foreign import writeStringImpl ::
   forall e. String -> Offset -> Int -> String -> Buffer -> Eff (buffer :: BUFFER | e) Int

--- a/src/Node/Encoding.purs
+++ b/src/Node/Encoding.purs
@@ -1,5 +1,6 @@
 module Node.Encoding
   ( Encoding (..)
+  , encodingToNode
   , byteLength
   ) where
 
@@ -15,15 +16,26 @@ data Encoding
   | Hex
 
 instance showEncoding :: Show Encoding where
-  show ASCII   = "ascii"
-  show UTF8    = "utf8"
-  show UTF16LE = "utf16le"
-  show UCS2    = "ucs2"
-  show Base64  = "base64"
-  show Binary  = "binary"
-  show Hex     = "hex"
+  show ASCII   = "ASCII"
+  show UTF8    = "UTF8"
+  show UTF16LE = "UTF16LE"
+  show UCS2    = "UCS2"
+  show Base64  = "Base64"
+  show Binary  = "Binary"
+  show Hex     = "Hex"
+
+-- | Convert an `Encoding` to a `String` in the format expected by Node.js
+-- | APIs.
+encodingToNode :: Encoding -> String
+encodingToNode ASCII   = "ascii"
+encodingToNode UTF8    = "utf8"
+encodingToNode UTF16LE = "utf16le"
+encodingToNode UCS2    = "ucs2"
+encodingToNode Base64  = "base64"
+encodingToNode Binary  = "binary"
+encodingToNode Hex     = "hex"
 
 foreign import byteLengthImpl :: String -> String -> Int
 
 byteLength :: String -> Encoding -> Int
-byteLength str enc = byteLengthImpl str (show enc)
+byteLength str enc = byteLengthImpl str (encodingToNode enc)


### PR DESCRIPTION
Encoding now obeys the informal Show law, and now has a separate
(monomorphic) function for converting to a String representation for
use with Node.js APIs.

It seems node.js doesn't care about the case - "ASCII", "Ascii", and "ascii" all seem to be handled equivalently (well, in node.js v4.2.2 at least). This isn't directly relevant to these changes, though.