### PR TITLE
Fixed Buffer DeprecationWarning

### DIFF
--- a/src/Node/Buffer.js
+++ b/src/Node/Buffer.js
@@ -7,20 +7,20 @@ exports.showImpl = require('util').inspect;
 
 exports.create = function (size) {
   return function() {
-    return new Buffer(size);
+    return Buffer.alloc(size);
   };
 };
 
 exports.fromArray = function (octets) {
   return function() {
-    return new Buffer(octets);
+    return Buffer.from(octets);
   };
 };
 
 exports.fromStringImpl = function (str) {
   return function (encoding) {
     return function() {
-      return new Buffer(str, encoding);
+      return Buffer.from(str, encoding);
     };
   };
 };


### PR DESCRIPTION
DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.