### PR TITLE
Use Number for reading and writing, fixes #25

### DIFF
--- a/src/Node/Buffer/Class.purs
+++ b/src/Node/Buffer/Class.purs
@@ -68,7 +68,7 @@ class Monad m <= MutableBuffer buf m | buf -> m where
   toArrayBuffer :: buf -> m ArrayBuffer
 
   -- | Reads a numeric value from a buffer at the specified offset.
-  read :: BufferValueType -> Offset -> buf -> m Int
+  read :: BufferValueType -> Offset -> buf -> m Number
 
   -- | Reads a section of a buffer as a string with the specified encoding.
   readString :: Encoding -> Offset -> Offset -> buf -> m String
@@ -77,7 +77,7 @@ class Monad m <= MutableBuffer buf m | buf -> m where
   toString :: Encoding -> buf -> m String
 
   -- | Writes a numeric value to a buffer at the specified offset.
-  write :: BufferValueType -> Int -> Offset -> buf -> m Unit
+  write :: BufferValueType -> Number -> Offset -> buf -> m Unit
 
   -- | Writes octets from a string to a buffer at the specified offset. Multi-byte
   -- | characters will not be written to the buffer if there is not enough capacity

--- a/src/Node/Buffer/Immutable.purs
+++ b/src/Node/Buffer/Immutable.purs
@@ -64,10 +64,10 @@ fromString str = fromStringImpl str <<< encodingToNode
 foreign import fromStringImpl :: String -> String -> ImmutableBuffer
 
 -- | Reads a numeric value from a buffer at the specified offset.
-read :: BufferValueType -> Offset -> ImmutableBuffer -> Int
+read :: BufferValueType -> Offset -> ImmutableBuffer -> Number
 read = readImpl <<< show
 
-foreign import readImpl :: String -> Offset -> ImmutableBuffer -> Int
+foreign import readImpl :: String -> Offset -> ImmutableBuffer -> Number
 
 -- | Reads a section of a buffer as a string with the specified encoding.
 readString :: Encoding -> Offset -> Offset -> ImmutableBuffer -> String

--- a/src/Node/Buffer/Internal.purs
+++ b/src/Node/Buffer/Internal.purs
@@ -64,7 +64,7 @@ fromArrayBuffer = usingToImmutable Immutable.fromArrayBuffer
 toArrayBuffer :: forall buf m. Monad m => buf -> m ArrayBuffer
 toArrayBuffer = usingFromImmutable Immutable.toArrayBuffer
 
-read :: forall buf m. Monad m => BufferValueType -> Offset -> buf -> m Int
+read :: forall buf m. Monad m => BufferValueType -> Offset -> buf -> m Number
 read t o = usingFromImmutable $ Immutable.read t o
 
 readString :: forall buf m. Monad m => Encoding -> Offset -> Offset -> buf -> m String
@@ -73,10 +73,10 @@ readString m o o' = usingFromImmutable $ Immutable.readString m o o'
 toString :: forall buf m. Monad m => Encoding -> buf -> m String
 toString m = usingFromImmutable $ Immutable.toString m
 
-write :: forall buf m. Monad m => BufferValueType -> Int -> Offset -> buf -> m Unit
+write :: forall buf m. Monad m => BufferValueType -> Number -> Offset -> buf -> m Unit
 write = writeInternal <<< show
 
-foreign import writeInternal :: forall buf m. String -> Int -> Offset -> buf -> m Unit
+foreign import writeInternal :: forall buf m. String -> Number -> Offset -> buf -> m Unit
 
 writeString :: forall buf m. Monad m => Encoding -> Offset -> Int -> String -> buf -> m Int
 writeString = writeStringInternal <<< encodingToNode

--- a/test/Test/Node/Buffer/Class.purs
+++ b/test/Test/Node/Buffer/Class.purs
@@ -80,7 +80,7 @@ testMutableBuffer _ run = do
 
     testReadWrite :: Effect Unit
     testReadWrite = do
-      let val = 42
+      let val = 42.0
       readVal <- run do
         buf <- create 1 :: m buf
         write UInt8 val 0 buf
@@ -94,7 +94,7 @@ testMutableBuffer _ run = do
         buf <- fromArray [1,2,3,4,5] :: m buf
         read UInt8 2 buf
 
-      assertEqual {expected: 3, actual: readVal}
+      assertEqual {expected: 3.0, actual: readVal}
 
     testToArray :: Effect Unit
     testToArray = do
@@ -112,7 +112,7 @@ testMutableBuffer _ run = do
         buf <- fromString str ASCII :: m buf
         read UInt8 6 buf
 
-      assertEqual {expected: 32, actual: val} -- ASCII space
+      assertEqual {expected: 32.0, actual: val} -- ASCII space
 
     testToFromArrayBuffer :: Effect Unit
     testToFromArrayBuffer = do

--- a/test/Test/Node/Buffer/Immutable.purs
+++ b/test/Test/Node/Buffer/Immutable.purs
@@ -82,7 +82,7 @@ testCreate = do
 testFromString :: Effect Unit
 testFromString = do
   let buf = Immutable.fromString "hello, world" ASCII
-  assertEqual {expected: 32, actual: Immutable.read UInt8 6 buf}
+  assertEqual {expected: 32.0, actual: Immutable.read UInt8 6 buf}
 
 testToString :: Effect Unit
 testToString = do


### PR DESCRIPTION
Int is not suitable for many of the options for BufferValueType, since
both UInt32 types as well as all of the floating point types are
inhabited by values which are not representable as Int.

This is quite a big breaking change unfortunately, but the library is
basically broken for about half of the BufferValueType constructors
right now, and this seems to me to be the most sensible way of fixing
it.

Note that {to,from}Array are unchanged because they deal with arrays of
octets.

Fixes #25 