### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Node/Buffer/Immutable.js
+++ b/src/Node/Buffer/Immutable.js
@@ -96,7 +96,7 @@ exports.concat = function (buffs) {
   return Buffer.concat(buffs);
 };
 
-exports["concat'"] = function (buffs) {
+exports.concatToLength = function (buffs) {
   return function (totalLength) {
     return Buffer.concat(buffs, totalLength);
   };

--- a/src/Node/Buffer/Immutable.purs
+++ b/src/Node/Buffer/Immutable.purs
@@ -100,7 +100,10 @@ foreign import concat :: Array ImmutableBuffer -> ImmutableBuffer
 
 -- | Concatenates a list of buffers, combining them into a new buffer of the
 -- | specified length.
-foreign import concat' :: Array ImmutableBuffer -> Int -> ImmutableBuffer
+concat' :: Array ImmutableBuffer -> Int -> ImmutableBuffer
+concat' = concatToLength
+
+foreign import concatToLength :: Array ImmutableBuffer -> Int -> ImmutableBuffer
 
 -- | Creates a new buffer slice that shares the memory of the original buffer.
 foreign import slice :: Offset -> Offset -> ImmutableBuffer -> ImmutableBuffer


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.