### PR TITLE
Don't return empty object for unit

### DIFF
--- a/src/Node/Buffer/Internal.js
+++ b/src/Node/Buffer/Internal.js
@@ -13,7 +13,6 @@ exports.writeInternal = function (ty) {
       return function (buf) {
         return function () {
           buf["write" + ty](value, offset);
-          return {};
         };
       };
     };
@@ -39,7 +38,6 @@ exports.setAtOffset = function (value) {
     return function (buff) {
       return function () {
         buff[offset] = value;
-        return {};
       };
     };
   };
@@ -65,7 +63,6 @@ exports.fill = function (octet) {
       return function (buf) {
         return function () {
           buf.fill(octet, start, end);
-          return {};
         };
       };
     };

--- a/src/Node/Buffer/Internal.purs
+++ b/src/Node/Buffer/Internal.purs
@@ -23,7 +23,8 @@ module Node.Buffer.Internal
   , concat
   , concat'
   , copy
-  , fill ) where
+  , fill
+  ) where
 
 import Prelude
 


### PR DESCRIPTION
This change removes `return {}` from functions which return no useful value (`Unit`), for a small performance benefit.